### PR TITLE
Changes for running LEGO.py

### DIFF
--- a/LEGO.py
+++ b/LEGO.py
@@ -4,17 +4,20 @@ import os
 import time
 
 import pyomo.environ as pyo
-from InOutModule import SQLiteWriter
-from InOutModule.ExcelWriter import ExcelWriter
-from InOutModule.CaseStudy import CaseStudy
-from InOutModule.printer import Printer
 from pyomo.core import NameLabeler
 from pyomo.util.infeasible import log_infeasible_constraints
 from rich_argparse import RichHelpFormatter
 
+from InOutModule import SQLiteWriter
+from InOutModule.CaseStudy import CaseStudy
+from InOutModule.ExcelWriter import ExcelWriter
+from InOutModule.printer import Printer
 from LEGO.LEGO import LEGO, ModelType
 
+LOGFILE = "LEGO.log"
+
 printer = Printer.getInstance()
+printer.set_logfile(LOGFILE)
 
 # Set up logging so that infeasible constraints are logged by pyomo
 logger = logging.getLogger("pyomo")

--- a/LEGO.py
+++ b/LEGO.py
@@ -29,13 +29,17 @@ def directory_path(string):
         raise argparse.ArgumentTypeError(f"Directory path not valid: '{string}'")
 
 
-def main(case_study_directory, model_type):
+def main(case_study_directory, model_type, number_of_rps, length_of_rps):
     # Load case study
     printer.information(f"Loading case study from '{case_study_directory}'")
     start_time = time.time()
     cs = CaseStudy(case_study_directory)
-    lego = LEGO(cs)
     printer.information(f"Loading case study took {time.time() - start_time:.2f} seconds")
+
+    if number_of_rps > 0:
+        cs.apply_kmedoids_aggregation(number_of_rps, length_of_rps)
+
+    lego = LEGO(cs)
 
     # Build LEGO model
     printer.information("Building LEGO model")
@@ -80,6 +84,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Starts LEGO for given case study", formatter_class=RichHelpFormatter)
     parser.add_argument("caseStudyDirectory", type=directory_path, help="Path to folder containing data for LEGO model")
     parser.add_argument("modelType", default=ModelType.DETERMINISTIC, type=lambda s: ModelType[s], choices=list(ModelType), nargs="?", help="ModelType of first model")
+    parser.add_argument("--numberOfRPs", type=int, default=0, help="Number of representative periods to cluster the data into")
+    parser.add_argument("--lengthOfRPs", type=int, default=24, help="Hours per representative period (e.g., 24, 48)")
     args = parser.parse_args()
 
-    main(args.caseStudyDirectory, args.modelType)
+    main(args.caseStudyDirectory, args.modelType, args.numberOfRPs, args.lengthOfRPs)

--- a/LEGO/modules/power.py
+++ b/LEGO/modules/power.py
@@ -181,12 +181,17 @@ def add_element_definitions_and_bounds(model: pyo.ConcreteModel, cs: CaseStudy) 
         completed_buses.add(index)
 
         # Set slack node
-        if cs.dPower_Parameters["is"] == None:
+        slack_node_parameter = cs.dPower_Parameters["is"]
+        if slack_node_parameter == "CALCULATE_FROM_MAX_DEMAND":
             printer.information(f"Determining slack node based on highest demand in this island...")
             slack_node = cs.dPower_Demand.loc[:, :, connected_buses].groupby('i').sum().idxmax().values[0]
+        elif slack_node_parameter not in model.i:
+            error_message = (f"Power_Parameters value for 'is' ({slack_node_parameter}) is not a known bus. "
+                             f"If you want the slack node to be calculated, use 'CALCULATE_FROM_MAX_DEMAND'.")
+            raise ValueError(error_message)
         else:
-            printer.information(f"Using predefined slack node from Power_Parameters: {cs.dPower_Parameters['is']}")
-            slack_node = cs.dPower_Parameters["is"]
+            printer.information(f"Using predefined slack node from Power_Parameters: {slack_node_parameter}")
+            slack_node = slack_node_parameter
         i += 1
         printer.information(f"Zone {i:>2} - Slack node: {slack_node}")
         for rp in model.rp:


### PR DESCRIPTION
- In `LEGO/modules/power.py`: the updated validation for slack node parameter now expects Slack node value `is` in `Power_Parameters.xlsx` to be set to `CALCULATE_FROM_MAX_DEMAND` in order for the slack node to be calculated.

- `LEGO.py` now is to be run with optional command line arguments (for clustering): 
```
python LEGO.py -h
Usage: LEGO.py [-h] [--numberOfRPs NUMBEROFRPS] [--lengthOfRPs LENGTHOFRPS]
               caseStudyDirectory
               [{ModelType.DETERMINISTIC,ModelType.EXTENSIVE_FORM,ModelType.BENDERS,ModelType.PROGRESSIVE_HEDGING}]

Starts LEGO for given case study

Positional Arguments:
  caseStudyDirectory    Path to folder containing data for LEGO model
  {ModelType.DETERMINISTIC,ModelType.EXTENSIVE_FORM,ModelType.BENDERS,ModelType.PROGRESSIVE_HEDGING}
                        ModelType of first model

Options:
  -h, --help            show this help message and exit
  --numberOfRPs NUMBEROFRPS
                        Number of representative periods to cluster the data into
  --lengthOfRPs LENGTHOFRPS
                        Hours per representative period (e.g., 24, 48)
```

- Running `LEGO.py` now also generates a file `LEGO.log` with the output from the run including timestamps (TODO).